### PR TITLE
missing dependencies for galactic, rolling test.

### DIFF
--- a/image_publisher/package.xml
+++ b/image_publisher/package.xml
@@ -22,6 +22,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>camera_info_manager</depend>
+  <depend>camera_calibration_parsers</depend>
   <depend>class_loader</depend>
   <depend>cv_bridge</depend>
   <depend>image_geometry</depend>

--- a/image_view/package.xml
+++ b/image_view/package.xml
@@ -18,6 +18,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>camera_info_manager</depend>
   <depend>camera_calibration_parsers</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>


### PR DESCRIPTION
This pr is just adding some missing depend statement to some package.xml files so that this [PR#651](https://github.com/ros-perception/image_pipeline/pull/651) builds and passes tests in ros2 galactic and ros2 rolling. I was able to build them locally (docker) and they passed all tests.